### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-update-using-golang.yml
+++ b/.github/workflows/auto-update-using-golang.yml
@@ -1,5 +1,7 @@
 # Name of the GitHub Actions workflow
 name: Run Go Script and Push Changes
+permissions:
+  contents: write
 
 # Define the events that trigger this workflow
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Strong-Foundation/ecolab-com-documentation/security/code-scanning/1](https://github.com/Strong-Foundation/ecolab-com-documentation/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly specify the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow pushes changes to the repository, it requires `contents: write`. The `permissions` block should be added at the top level of the workflow (just after the `name:` and before `on:`), so it applies to all jobs unless overridden. No other permissions appear to be needed for this workflow.

**Steps:**
- Insert a `permissions:` block after the `name:` line (line 2), specifying `contents: write`.
- No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
